### PR TITLE
Fix build on Mac for >=4.22.0

### DIFF
--- a/ue4cli/UnrealManagerDarwin.py
+++ b/ue4cli/UnrealManagerDarwin.py
@@ -35,8 +35,8 @@ class UnrealManagerDarwin(UnrealManagerUnix):
 		return '.app/Contents/MacOS/UE4Editor'
 	
 	def _transformBuildToolPlatform(self, platform):
-		# Build.sh under Mac requires "macosx" as the platform name for macOS
-		return 'macosx' if platform == 'Mac' else platform
+		# Before 4.22.2, Build.sh under Mac requires "macosx" as the platform name for macOS
+		return 'macosx' if platform == 'Mac' and self.getEngineVersion() >= "4.22.2" else platform
 	
 	def _getRunXBuildScript(self):
 		xbuildScript = super(UnrealManagerDarwin, self)._getRunXBuildScript()

--- a/ue4cli/UnrealManagerDarwin.py
+++ b/ue4cli/UnrealManagerDarwin.py
@@ -36,7 +36,7 @@ class UnrealManagerDarwin(UnrealManagerUnix):
 	
 	def _transformBuildToolPlatform(self, platform):
 		# Before 4.22.2, Build.sh under Mac requires "macosx" as the platform name for macOS
-		return 'macosx' if platform == 'Mac' and self.getEngineVersion() >= "4.22.2" else platform
+		return 'macosx' if platform == 'Mac' and self.getEngineVersion() < "4.22.2" else platform
 	
 	def _getRunXBuildScript(self):
 		xbuildScript = super(UnrealManagerDarwin, self)._getRunXBuildScript()


### PR DESCRIPTION
I came across https://github.com/adamrehn/ue4cli/issues/3 and, while investigating, found out that the target platform transformation logic should no longer be applied after [Build.sh was changed](https://github.com/EpicGames/UnrealEngine/commit/ab108c215e0f05f3512862ed6f2e54c92e3ac093#diff-5695c29468e67a3cc8e05cdc7f30c87e).