### PR TITLE
Only test for 'Engine/Source/ThirdParty' in _getThirdPartyLibs.

### DIFF
--- a/ue4cli/UE4BuildInterrogator.py
+++ b/ue4cli/UE4BuildInterrogator.py
@@ -160,7 +160,7 @@ class UE4BuildInterrogator(object):
 		modules = [result['Modules'][key] for key in result['Modules']]
 		
 		# Filter out any modules from outside the Engine/Source/ThirdParty directory
-		thirdPartyRoot = os.path.join(self.engineRoot, 'Engine', 'Source', 'ThirdParty')
+		thirdPartyRoot = os.path.join('Engine', 'Source', 'ThirdParty')
 		thirdparty = list([m for m in modules if thirdPartyRoot in m['Directory']])
 		
 		# Remove the temp directory


### PR DESCRIPTION
Since the intermediate ubt_output.json contains canonicalized paths
whereas the engine root may not, comparing the full path of the module
locations might fail. Thus, no modules would be enumerated.