### PR TITLE
Add --enableeditor arg that omits -game flag in runAutomationCommands

### DIFF
--- a/ue4cli/UnrealManagerBase.py
+++ b/ue4cli/UnrealManagerBase.py
@@ -445,7 +445,7 @@ class UnrealManagerBase(object):
 		else:
 			self.packagePlugin(dir, args)
 	
-	def runAutomationCommands(self, projectFile, commands, extraArgs, capture=False, enableRHI=False):
+	def runAutomationCommands(self, projectFile, commands, extraArgs, capture=False, enableRHI=False, disableGameArg=False):
 		'''
 		Invokes the Automation Test commandlet for the specified project with the supplied automation test commands
 		'''
@@ -461,7 +461,9 @@ class UnrealManagerBase(object):
 		# preventing them from executing correctly.
 		
 		command = '{} {}'.format(Utility.escapePathForShell(self.getEditorBinary(True)), Utility.escapePathForShell(projectFile))
-		command += ' -game -buildmachine -stdout -fullstdoutlogoutput -forcelogflush -unattended -nopause -nosplash'
+		if disableGameArg == False:
+		  command += ' -game'
+		command += ' -buildmachine -stdout -fullstdoutlogoutput -forcelogflush -unattended -nopause -nosplash'
 		if enableRHI == False:
 			command += ' -nullrhi'
 		command += ' -ExecCmds="automation {};quit" '.format(';'.join(commands))
@@ -502,6 +504,10 @@ class UnrealManagerBase(object):
 		
 		# Determine if rendering should be enabled
 		enableRHI = len(Utility.findArgs(args, ['--withrhi'])) > 0
+		args = Utility.stripArgs(args, ['--withrhi'])
+		
+		# Determine if tests should be run as a game 
+		disableGameArg = len(Utility.findArgs(args, ['--notgame'])) > 0
 		args = Utility.stripArgs(args, ['--withrhi'])
 		
 		# Verify that at least one argument was supplied
@@ -546,7 +552,7 @@ class UnrealManagerBase(object):
 			
 			# Attempt to run the automation tests
 			Utility.printStderr('Running automation tests...')
-			logOutput = self.runAutomationCommands(projectFile, command, extraArgs, capture=True, enableRHI=enableRHI)
+			logOutput = self.runAutomationCommands(projectFile, command, extraArgs, capture=True, enableRHI=enableRHI, disableGameArg=disableGameArg)
 			
 			# Propagate the log output
 			print(logOutput.stdout)


### PR DESCRIPTION
**Problem** 
The automatic inclusion of the `-game` when calling the editor binary prevents use of `ue4cli` with editor plugins.

**Proposed solution**
Include `-game` by default but enable its omission with a `--notgame` flag 

**Notes**
Explored multiple argument signatures
- `--enableeditor` Was misleading because it implies that the "UnrealEditor" is disabled. 
- `--editorplugin` Was misleading because other arguments would need to be used in conjunction with this argument for editor plugins
- `--notgame` Seemed to be the most concise

Resolves #22 