### PR TITLE
Remove engine root message.

### DIFF
--- a/ue4cli/UnrealManagerBase.py
+++ b/ue4cli/UnrealManagerBase.py
@@ -590,7 +590,6 @@ class UnrealManagerBase(object):
 		"""
 		override = ConfigurationManager.getConfigKey('rootDirOverride')
 		if override != None:
-			Utility.printStderr('Using user-specified engine root: ' + override)
 			return override
 		else:
 			return self._detectEngineRoot()


### PR DESCRIPTION
User can use ue4 root to determine which root is in use.

I always use a non-standard root, and this message constantly clutters the output.