### PR TITLE
Simple fix for index out of range for Library subcmds

### DIFF
--- a/ue4cli/UnrealManagerBase.py
+++ b/ue4cli/UnrealManagerBase.py
@@ -193,15 +193,17 @@ class UnrealManagerBase(object):
 		Retrieves the compiler flags for building against the Unreal-bundled versions of the specified third-party libraries
 		"""
 		fmt = PrintingFormat.singleLine()
-		if libs[0] == '--multiline':
-			fmt = PrintingFormat.multiLine()
-			libs = libs[1:]
-		
 		platformDefaults = True
-		if libs[0] == '--nodefaults':
-			platformDefaults = False
-			libs = libs[1:]
-		
+
+		if libs:
+			if libs[0] == '--multiline':
+				fmt = PrintingFormat.multiLine()
+				libs = libs[1:]
+
+			if libs[0] == '--nodefaults':
+				platformDefaults = False
+				libs = libs[1:]
+
 		details = self.getThirdpartyLibs(libs, includePlatformDefaults=platformDefaults)
 		return details.getCompilerFlags(self.getEngineRoot(), fmt)
 	
@@ -210,20 +212,22 @@ class UnrealManagerBase(object):
 		Retrieves the linker flags for building against the Unreal-bundled versions of the specified third-party libraries
 		"""
 		fmt = PrintingFormat.singleLine()
-		if libs[0] == '--multiline':
-			fmt = PrintingFormat.multiLine()
-			libs = libs[1:]
-		
 		includeLibs = True
-		if (libs[0] == '--flagsonly'):
-			includeLibs = False
-			libs = libs[1:]
-		
 		platformDefaults = True
-		if libs[0] == '--nodefaults':
-			platformDefaults = False
-			libs = libs[1:]
-		
+
+		if libs:
+			if libs[0] == '--multiline':
+				fmt = PrintingFormat.multiLine()
+				libs = libs[1:]
+
+			if (libs[0] == '--flagsonly'):
+				includeLibs = False
+				libs = libs[1:]
+
+			if libs[0] == '--nodefaults':
+				platformDefaults = False
+				libs = libs[1:]
+
 		details = self.getThirdpartyLibs(libs, includePlatformDefaults=platformDefaults)
 		return details.getLinkerFlags(self.getEngineRoot(), fmt, includeLibs)
 	
@@ -232,15 +236,17 @@ class UnrealManagerBase(object):
 		Retrieves the CMake invocation flags for building against the Unreal-bundled versions of the specified third-party libraries
 		"""
 		fmt = PrintingFormat.singleLine()
-		if libs[0] == '--multiline':
-			fmt = PrintingFormat.multiLine()
-			libs = libs[1:]
-		
 		platformDefaults = True
-		if libs[0] == '--nodefaults':
-			platformDefaults = False
-			libs = libs[1:]
-		
+
+		if libs:
+			if libs[0] == '--multiline':
+				fmt = PrintingFormat.multiLine()
+				libs = libs[1:]
+
+			if libs[0] == '--nodefaults':
+				platformDefaults = False
+				libs = libs[1:]
+
 		details = self.getThirdpartyLibs(libs, includePlatformDefaults=platformDefaults)
 		CMakeCustomFlags.processLibraryDetails(details)
 		return details.getCMakeFlags(self.getEngineRoot(), fmt)
@@ -250,10 +256,10 @@ class UnrealManagerBase(object):
 		Retrieves the list of include directories for building against the Unreal-bundled versions of the specified third-party libraries
 		"""
 		platformDefaults = True
-		if libs[0] == '--nodefaults':
+		if libs and libs[0] == '--nodefaults':
 			platformDefaults = False
 			libs = libs[1:]
-		
+
 		details = self.getThirdpartyLibs(libs, includePlatformDefaults=platformDefaults)
 		return details.getIncludeDirectories(self.getEngineRoot(), delimiter='\n')
 	
@@ -262,10 +268,10 @@ class UnrealManagerBase(object):
 		Retrieves the list of library files for building against the Unreal-bundled versions of the specified third-party libraries
 		"""
 		platformDefaults = True
-		if libs[0] == '--nodefaults':
+		if libs and libs[0] == '--nodefaults':
 			platformDefaults = False
 			libs = libs[1:]
-		
+
 		details = self.getThirdpartyLibs(libs, includePlatformDefaults=platformDefaults)
 		return details.getLibraryFiles(self.getEngineRoot(), delimiter='\n')
 	
@@ -274,7 +280,7 @@ class UnrealManagerBase(object):
 		Retrieves the list of preprocessor definitions for building against the Unreal-bundled versions of the specified third-party libraries
 		"""
 		platformDefaults = True
-		if libs[0] == '--nodefaults':
+		if libs and libs[0] == '--nodefaults':
 			platformDefaults = False
 			libs = libs[1:]
 		


### PR DESCRIPTION

Fix errors like the one below:
$ ue4 cxxflags
Traceback (most recent call last):
  File "/usr/local/bin/ue4", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.8/dist-packages/ue4cli/cli.py", line 222, in main
    SUPPORTED_COMMANDS[command]['action'](manager, args)
  File "/usr/local/lib/python3.8/dist-packages/ue4cli/cli.py", line 106, in <lambda>
    'action': lambda m, args: print(m.getThirdPartyLibCompilerFlags(args)),
  File "/usr/local/lib/python3.8/dist-packages/ue4cli/UnrealManagerBase.py", line 199, in getThirdPartyLibCompilerFlags
    if libs[0] == '--multiline':
IndexError: list index out of range