### PR TITLE
Add new flag to preserve debug files as needed

### DIFF
--- a/ue4cli/UnrealManagerBase.py
+++ b/ue4cli/UnrealManagerBase.py
@@ -408,7 +408,13 @@ class UnrealManagerBase(object):
 			extraArgs.append('-serverplatform={}'.format(platform))
 		
 		# If we are packaging a Shipping build, do not include debug symbols
-		if configuration == 'Shipping':
+		preserveDebugArgs = Utility.findArgs(extraArgs, ['-preservedebug'])
+		if len(preserveDebugArgs) > 0:
+			stripDebug = False
+		else:
+			stripDebug = configuration == 'Shipping'
+		extraArgs = Utility.stripArgs(extraArgs, ['-preservedebug'])
+		if stripDebug:
 			extraArgs.append('-nodebuginfo')
 		
 		# Define the usage of pak files, default value is pak files for all platforms except HTML5


### PR DESCRIPTION
I called it `-preservedebug`. If the flag is not passed, the original behavior is maintained — which is to automatically strip the debug files in shipping builds.