### PR TITLE
Fix UnrealManagerDarwin

### DIFF
--- a/ue4cli/UnrealManagerDarwin.py
+++ b/ue4cli/UnrealManagerDarwin.py
@@ -22,11 +22,6 @@ class UnrealManagerDarwin(UnrealManagerUnix):
 		
 		# Under macOS, the default installation path is `/Users/Shared/Epic Games/UE_4.XX/UE_5.XX`
 		baseDir = '/Users/Shared/Epic Games/'
-		version = parse_version(self.getEngineVersion())
-		if version < parse_version('5.0.0'):
-			prefix = 'UE_4.'
-		else:
-			prefix = 'UE_5.'
 		prefix = 'UE_4.'
 		versionDirs = glob.glob(baseDir + prefix + '*')
 		if len(versionDirs) > 0:

--- a/ue4cli/UnrealManagerDarwin.py
+++ b/ue4cli/UnrealManagerDarwin.py
@@ -22,6 +22,7 @@ class UnrealManagerDarwin(UnrealManagerUnix):
 		
 		# Under macOS, the default installation path is `/Users/Shared/Epic Games/UE_4.XX/UE_5.XX`
 		baseDir = '/Users/Shared/Epic Games/'
+		version = parse_version(self.getEngineVersion())
 		if version < parse_version('5.0.0'):
 			prefix = 'UE_4.'
 		else:


### PR DESCRIPTION
I'm currently getting this error when running `ue4 root`, `ue4 version` and probably more.

```sh
# ue4 root
Traceback (most recent call last):
  File "/usr/local/bin/ue4", line 8, in <module>
    sys.exit(main())
  File "/Library/Python/3.8/site-packages/ue4cli/cli.py", line 222, in main
    SUPPORTED_COMMANDS[command]['action'](manager, args)
  File "/Library/Python/3.8/site-packages/ue4cli/cli.py", line 36, in <lambda>
    'action': lambda m, args: print(m.getEngineRoot()),
  File "/Library/Python/3.8/site-packages/ue4cli/UnrealManagerBase.py", line 60, in getEngineRoot
    self._engineRoot = self._getEngineRoot()
  File "/Library/Python/3.8/site-packages/ue4cli/UnrealManagerBase.py", line 620, in _getEngineRoot
    return self._detectEngineRoot()
  File "/Library/Python/3.8/site-packages/ue4cli/UnrealManagerDarwin.py", line 25, in _detectEngineRoot
    if version < parse_version('5.0.0'):
NameError: name 'version' is not defined
```

I think this patch solves the problem, however I haven't tested it.
