### PR TITLE
Fix infinite recursion in root detection code and lack of UE5 detection

### DIFF
--- a/ue4cli/UnrealManagerDarwin.py
+++ b/ue4cli/UnrealManagerDarwin.py
@@ -22,11 +22,11 @@ class UnrealManagerDarwin(UnrealManagerUnix):
 		
 		# Under macOS, the default installation path is `/Users/Shared/Epic Games/UE_4.XX/UE_5.XX`
 		baseDir = '/Users/Shared/Epic Games/'
+		version = parse_version(self.getEngineVersion())
 		if version < parse_version('5.0.0'):
 			prefix = 'UE_4.'
 		else:
 			prefix = 'UE_5.'
-		prefix = 'UE_4.'
 		versionDirs = glob.glob(baseDir + prefix + '*')
 		if len(versionDirs) > 0:
 			installedVersions = sorted([int(os.path.basename(d).replace(prefix, '')) for d in versionDirs])

--- a/ue4cli/UnrealManagerDarwin.py
+++ b/ue4cli/UnrealManagerDarwin.py
@@ -22,19 +22,16 @@ class UnrealManagerDarwin(UnrealManagerUnix):
 		
 		# Under macOS, the default installation path is `/Users/Shared/Epic Games/UE_4.XX/UE_5.XX`
 		baseDir = '/Users/Shared/Epic Games/'
-		version = parse_version(self.getEngineVersion())
-		if version < parse_version('5.0.0'):
-			prefix = 'UE_4.'
-		else:
-			prefix = 'UE_5.'
-		versionDirs = glob.glob(baseDir + prefix + '*')
-		if len(versionDirs) > 0:
-			installedVersions = sorted([int(os.path.basename(d).replace(prefix, '')) for d in versionDirs])
-			newestVersion = max(installedVersions)
-			return baseDir + prefix + str(newestVersion)
+		prefixes = ['UE_5.', 'UE_4.']
+		for prefix in prefixes:
+			versionDirs = glob.glob(baseDir + prefix + '*')
+			if len(versionDirs) > 0:
+				installedVersions = sorted([int(os.path.basename(d).replace(prefix, '')) for d in versionDirs])
+				newestVersion = max(installedVersions)
+				return baseDir + prefix + str(newestVersion)
 		
 		# Could not auto-detect the Unreal Engine location
-		raise UnrealManagerException('could not detect the location of the latest installed Unreal Engine version')
+		return None
 	
 	def _editorPathSuffix(self, cmdVersion):
 		version = parse_version(self.getEngineVersion())

--- a/ue4cli/UnrealManagerLinux.py
+++ b/ue4cli/UnrealManagerLinux.py
@@ -11,26 +11,28 @@ class UnrealManagerLinux(UnrealManagerUnix):
 	
 	def _detectEngineRoot(self):
 		
+		# FIXME: With current setup, 'UE4Editor' can be returned instead of:
+		# 'UnrealEditor.desktop' or 'com.epicgames.UnrealEngineEditor.desktop',
+		# which will mean that NOT the highest version will be returned.
+		# Such case would be very rare (mixing different ways of instalations) but it can happen!
+		# (this was always a problem)
+		
 		# If UE4Editor/UnrealEditor is available in the PATH, use its location to detect the root directory path
-		if self._getEngineVersionDetails()['MajorVersion'] >= 5:
-			editorLoc = Utility.capture(['which', 'UnrealEditor']).stdout.strip()
-		else:
-			editorLoc = Utility.capture(['which', 'UE4Editor']).stdout.strip()
-		if editorLoc != '':
-			editorLoc = os.path.dirname(os.path.realpath(editorLoc))
-			return os.path.abspath(editorLoc + '/../../..')
+		potentialEditorLocs = [
+			Utility.capture(['which', 'UnrealEditor']).stdout.strip(),
+			Utility.capture(['which', 'UE4Editor']).stdout.strip(),
+		]
+		for editorLoc in potentialEditorLocs:
+			if editorLoc != '':
+				editorLoc = os.path.dirname(os.path.realpath(editorLoc))
+				return os.path.abspath(editorLoc + '/../../..')
 		
 		# Under Debian-based systems, we can use the desktop integration to find UE4Editor/UnrealEditor
-		if self._getEngineVersionDetails()['MajorVersion'] >= 5:
-			potentialLauncherPaths = [
-				os.path.join(os.environ['HOME'], '.local', 'share', 'applications', 'UnrealEditor.desktop'),
-				os.path.join(os.environ['HOME'], '.local', 'share', 'applications', 'com.epicgames.UnrealEngineEditor.desktop')
-			]
-		else:
-			potentialLauncherPaths = [
-				os.path.join(os.environ['HOME'], '.local', 'share', 'applications', 'UE4.desktop'),
-				os.path.join(os.environ['HOME'], '.local', 'share', 'applications', 'com.epicgames.UnrealEngineEditor.desktop')
-			]
+		potentialLauncherPaths = [
+			os.path.join(os.environ['HOME'], '.local', 'share', 'applications', 'UnrealEditor.desktop'),
+			os.path.join(os.environ['HOME'], '.local', 'share', 'applications', 'com.epicgames.UnrealEngineEditor.desktop'),
+			os.path.join(os.environ['HOME'], '.local', 'share', 'applications', 'UE4.desktop'),
+		]
 		for launcherPath in potentialLauncherPaths:
 			if os.path.exists(launcherPath):
 				with open(launcherPath, 'r') as f:

--- a/ue4cli/UnrealManagerWindows.py
+++ b/ue4cli/UnrealManagerWindows.py
@@ -62,15 +62,16 @@ class UnrealManagerWindows(UnrealManagerBase):
 		
 		# Under Windows, the default installation path is `%PROGRAMFILES%\Epic Games`
 		baseDir = os.environ['PROGRAMFILES'] + '\\Epic Games\\'
-		prefix = 'UE_4.'
-		versionDirs = glob.glob(baseDir + prefix + '*')
-		if len(versionDirs) > 0:
-			installedVersions = sorted([int(os.path.basename(d).replace(prefix, '')) for d in versionDirs])
-			newestVersion = max(installedVersions)
-			return baseDir + prefix + str(newestVersion)
+		prefixes = ['UE_5.', 'UE_4.']
+		for prefix in prefixes:
+			versionDirs = glob.glob(baseDir + prefix + '*')
+			if len(versionDirs) > 0:
+				installedVersions = sorted([int(os.path.basename(d).replace(prefix, '')) for d in versionDirs])
+				newestVersion = max(installedVersions)
+				return baseDir + prefix + str(newestVersion)
 		
 		# Could not auto-detect the Unreal Engine location
-		raise UnrealManagerException('could not detect the location of the latest installed Unreal Engine 4 version')
+		return None
 	
 	def _editorPathSuffix(self, cmdVersion):
 		return '-Cmd.exe' if cmdVersion == True else '.exe'


### PR DESCRIPTION
TLDR - This PR fixes: https://github.com/adamrehn/ue4cli/issues/57 ,  https://github.com/adamrehn/ue4cli/issues/55 , https://github.com/adamrehn/ue4cli/issues/47 , https://github.com/adamrehn/ue4cli/pull/50 and few more things in the same code (see below)

Hey @adamrehn, I hope you are doing well!

In almost every UnrealManager... class there was a bug resulting in infinite recursion. It was caused by the usage of `getEngineVersion()` inside of `_detectEngineRoot()` which would never work - `getEngineVersion()` expects that Root is already known when said function is called, and the `_detectEngineRoot()` is only called when Root is NOT known, this leads to recursion in multiple cases. I just removed the `getEngineVersion()`  function call, it's not needed there at all. Additionally, `_detectEngineRoot()` was not working consistently across platforms, some of them were not detecting UE5. I fixed it, since it's the same code.

Let me know, if something is not right.

All changes done by this PR:
- remove `UnrealManagerBase::_getEngineRoot()`, it was only used in one place and hiding the code, split and move it's logic to the `UnrealManagerBase::getEngineRoot` and to the new function `UnrealManagerBase::getEngineRootOverride`
- move assertions from `_detectEngineRoot` overrides to `UnrealManagerBase::getEngineRoot()`. Some managers were not calling these assertions. Now each `_detectEngineRoot` will return `None` while failing to detect the Root which throws the same assertion shortly after. This is easier to maintain and probably makes more sense.
- fix: remove `_getEngineVersionDetails` function call from each `_detectEngineRoot` - it made no sense, was not needed and was causing the recursions. 
- fix: NameError in `UnrealManagerDarwin::_detectEngineRoot`
- fix: lack of UE5 detection on Windows in `UnrealManagerWindows::_detectEngineRoot`
- change assert message about root detection fail to be more meaningful: `'could not detect Unreal Engine root directory! Please, provide it manually via: ue4 setroot <ROOTDIR>'`
- add note to `UnrealManagerLinux::_detectEngineRoot` about possible bug with engine detection order 

Tested on ArchLinux with UE5.3.2 built from source, and on Win11 with UE5.3.2 downloaded via EpicGamesLauncher.
Sadly, I can't confirm if this works everywhere, there is too many of cases to test.

Cheers!