### PR TITLE
Replace shellescape with shlex, drop shellescape dependency entirely 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ if: tag IS present
 dist: xenial
 language: python
 python:
-- '3.8'
+- '3.7'
 install:
 - pip install wheel
 script: echo "No build-time tests to run."

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ if: tag IS present
 dist: xenial
 language: python
 python:
-- '3.7'
+- '3.8'
 install:
 - pip install wheel
 script: echo "No build-time tests to run."

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,9 @@ setup(
 	long_description_content_type='text/markdown',
 	classifiers=[
 		'License :: OSI Approved :: MIT License',
-		'Programming Language :: Python :: 3.8',
+		'Programming Language :: Python :: 3.5',
+		'Programming Language :: Python :: 3.6',
+		'Programming Language :: Python :: 3.7',
 		'Topic :: Software Development :: Build Tools',
 		'Environment :: Console'
 	],
@@ -24,9 +26,10 @@ setup(
 	license='MIT',
 	packages=['ue4cli'],
 	zip_safe=True,
-	python_requires = '>=3.8',
+	python_requires = '>=3.5',
 	install_requires = [
 		'setuptools>=38.6.0',
+		'shellescape',
 		'twine>=1.11.0',
 		'wheel>=0.31.0'
 	],

--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,7 @@ setup(
 	long_description_content_type='text/markdown',
 	classifiers=[
 		'License :: OSI Approved :: MIT License',
-		'Programming Language :: Python :: 3.5',
-		'Programming Language :: Python :: 3.6',
-		'Programming Language :: Python :: 3.7',
+		'Programming Language :: Python :: 3.8',
 		'Topic :: Software Development :: Build Tools',
 		'Environment :: Console'
 	],
@@ -26,10 +24,9 @@ setup(
 	license='MIT',
 	packages=['ue4cli'],
 	zip_safe=True,
-	python_requires = '>=3.5',
+	python_requires = '>=3.8',
 	install_requires = [
 		'setuptools>=38.6.0',
-		'shellescape',
 		'twine>=1.11.0',
 		'wheel>=0.31.0'
 	],

--- a/ue4cli/Utility.py
+++ b/ue4cli/Utility.py
@@ -1,4 +1,4 @@
-import os, platform, shellescape, subprocess, sys
+import os, platform, shlex, subprocess, sys
 
 class CommandOutput(object):
 	"""
@@ -66,7 +66,7 @@ class Utility:
 		if platform.system() == 'Windows':
 			return '"{}"'.format(path.replace('"', '""'))
 		else:
-			return shellescape.quote(path)
+			return shlex.quote(path)
 	
 	@staticmethod
 	def join(delim, items, quotes=False):

--- a/ue4cli/Utility.py
+++ b/ue4cli/Utility.py
@@ -1,4 +1,4 @@
-import os, platform, shellescape, subprocess, sys
+import os, platform, shlex, subprocess, sys
 
 class CommandOutput(object):
 	"""
@@ -14,14 +14,14 @@ class Utility:
 	"""
 	Provides utility functionality
 	"""
-	
+
 	@staticmethod
 	def printStderr(*args, **kwargs):
 		"""
 		Prints to stderr instead of stdout
 		"""
 		print(*args, file=sys.stderr, **kwargs)
-	
+
 	@staticmethod
 	def readFile(filename):
 		"""
@@ -29,7 +29,7 @@ class Utility:
 		"""
 		with open(filename, 'rb') as f:
 			return f.read().decode('utf-8')
-	
+
 	@staticmethod
 	def writeFile(filename, data):
 		"""
@@ -37,27 +37,27 @@ class Utility:
 		"""
 		with open(filename, 'wb') as f:
 			f.write(data.encode('utf-8'))
-	
+
 	@staticmethod
 	def patchFile(filename, replacements):
 		"""
 		Applies the supplied list of replacements to a file
 		"""
 		patched = Utility.readFile(filename)
-		
+
 		# Perform each of the replacements in the supplied dictionary
 		for key in replacements:
 			patched = patched.replace(key, replacements[key])
-		
+
 		Utility.writeFile(filename, patched)
-	
+
 	@staticmethod
 	def forwardSlashes(paths):
 		"""
 		Replaces Windows directory separators with Unix separators
 		"""
 		return list([p.replace('\\', '/') for p in paths])
-	
+
 	@staticmethod
 	def escapePathForShell(path):
 		"""
@@ -66,8 +66,8 @@ class Utility:
 		if platform.system() == 'Windows':
 			return '"{}"'.format(path.replace('"', '""'))
 		else:
-			return shellescape.quote(path)
-	
+			return shlex.quote(path)
+
 	@staticmethod
 	def join(delim, items, quotes=False):
 		"""
@@ -76,12 +76,12 @@ class Utility:
 		transform = lambda s: s
 		if quotes == True:
 			transform = lambda s: s if ' ' not in s else '"{}"'.format(s)
-		
+
 		stripped = list([transform(i) for i in items if len(i) > 0])
 		if len(stripped) > 0:
 			return delim.join(stripped)
 		return ''
-	
+
 	@staticmethod
 	def findArgs(args, prefixes):
 		"""
@@ -91,14 +91,14 @@ class Utility:
 			arg for arg in args
 			if len([p for p in prefixes if arg.lower().startswith(p.lower())]) > 0
 		])
-	
+
 	@staticmethod
 	def getArgValue(arg):
 		"""
 		Returns the value component of an argument with the format `-KEY=VALUE`
 		"""
 		return arg.split('=', maxsplit=1)[1]
-	
+
 	@staticmethod
 	def stripArgs(args, blacklist):
 		"""
@@ -106,20 +106,20 @@ class Utility:
 		"""
 		blacklist = [b.lower() for b in blacklist]
 		return list([arg for arg in args if arg.lower() not in blacklist])
-	
+
 	@staticmethod
 	def capture(command, input=None, cwd=None, shell=False, raiseOnError=False):
 		"""
 		Executes a child process and captures its output
 		"""
-		
+
 		# If verbose output is enabled, print the command that will be executed
 		Utility._printCommand(command)
-		
+
 		# Attempt to execute the child process
 		proc = subprocess.Popen(command, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=cwd, shell=shell, universal_newlines=True)
 		(stdout, stderr) = proc.communicate(input)
-		
+
 		# If the child process failed and we were asked to raise an exception, do so
 		if raiseOnError == True and proc.returncode != 0:
 			raise Exception(
@@ -128,23 +128,23 @@ class Utility:
 				'\nstdout: "' + stdout + '"' +
 				'\nstderr: "' + stderr + '"'
 			)
-		
+
 		return CommandOutput(proc.returncode, stdout, stderr)
-	
+
 	@staticmethod
 	def run(command, cwd=None, shell=False, raiseOnError=False):
 		"""
 		Executes a child process and waits for it to complete
 		"""
-		
+
 		# If verbose output is enabled, print the command that will be executed
 		Utility._printCommand(command)
-		
+
 		returncode = subprocess.call(command, cwd=cwd, shell=shell)
 		if raiseOnError == True and returncode != 0:
 			raise Exception('child process ' + str(command) + ' failed with exit code ' + str(returncode))
 		return returncode
-	
+
 	@staticmethod
 	def _printCommand(command):
 		"""

--- a/ue4cli/Utility.py
+++ b/ue4cli/Utility.py
@@ -1,4 +1,4 @@
-import os, platform, shlex, subprocess, sys
+import os, platform, shellescape, subprocess, sys
 
 class CommandOutput(object):
 	"""
@@ -14,14 +14,14 @@ class Utility:
 	"""
 	Provides utility functionality
 	"""
-
+	
 	@staticmethod
 	def printStderr(*args, **kwargs):
 		"""
 		Prints to stderr instead of stdout
 		"""
 		print(*args, file=sys.stderr, **kwargs)
-
+	
 	@staticmethod
 	def readFile(filename):
 		"""
@@ -29,7 +29,7 @@ class Utility:
 		"""
 		with open(filename, 'rb') as f:
 			return f.read().decode('utf-8')
-
+	
 	@staticmethod
 	def writeFile(filename, data):
 		"""
@@ -37,27 +37,27 @@ class Utility:
 		"""
 		with open(filename, 'wb') as f:
 			f.write(data.encode('utf-8'))
-
+	
 	@staticmethod
 	def patchFile(filename, replacements):
 		"""
 		Applies the supplied list of replacements to a file
 		"""
 		patched = Utility.readFile(filename)
-
+		
 		# Perform each of the replacements in the supplied dictionary
 		for key in replacements:
 			patched = patched.replace(key, replacements[key])
-
+		
 		Utility.writeFile(filename, patched)
-
+	
 	@staticmethod
 	def forwardSlashes(paths):
 		"""
 		Replaces Windows directory separators with Unix separators
 		"""
 		return list([p.replace('\\', '/') for p in paths])
-
+	
 	@staticmethod
 	def escapePathForShell(path):
 		"""
@@ -66,8 +66,8 @@ class Utility:
 		if platform.system() == 'Windows':
 			return '"{}"'.format(path.replace('"', '""'))
 		else:
-			return shlex.quote(path)
-
+			return shellescape.quote(path)
+	
 	@staticmethod
 	def join(delim, items, quotes=False):
 		"""
@@ -76,12 +76,12 @@ class Utility:
 		transform = lambda s: s
 		if quotes == True:
 			transform = lambda s: s if ' ' not in s else '"{}"'.format(s)
-
+		
 		stripped = list([transform(i) for i in items if len(i) > 0])
 		if len(stripped) > 0:
 			return delim.join(stripped)
 		return ''
-
+	
 	@staticmethod
 	def findArgs(args, prefixes):
 		"""
@@ -91,14 +91,14 @@ class Utility:
 			arg for arg in args
 			if len([p for p in prefixes if arg.lower().startswith(p.lower())]) > 0
 		])
-
+	
 	@staticmethod
 	def getArgValue(arg):
 		"""
 		Returns the value component of an argument with the format `-KEY=VALUE`
 		"""
 		return arg.split('=', maxsplit=1)[1]
-
+	
 	@staticmethod
 	def stripArgs(args, blacklist):
 		"""
@@ -106,20 +106,20 @@ class Utility:
 		"""
 		blacklist = [b.lower() for b in blacklist]
 		return list([arg for arg in args if arg.lower() not in blacklist])
-
+	
 	@staticmethod
 	def capture(command, input=None, cwd=None, shell=False, raiseOnError=False):
 		"""
 		Executes a child process and captures its output
 		"""
-
+		
 		# If verbose output is enabled, print the command that will be executed
 		Utility._printCommand(command)
-
+		
 		# Attempt to execute the child process
 		proc = subprocess.Popen(command, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=cwd, shell=shell, universal_newlines=True)
 		(stdout, stderr) = proc.communicate(input)
-
+		
 		# If the child process failed and we were asked to raise an exception, do so
 		if raiseOnError == True and proc.returncode != 0:
 			raise Exception(
@@ -128,23 +128,23 @@ class Utility:
 				'\nstdout: "' + stdout + '"' +
 				'\nstderr: "' + stderr + '"'
 			)
-
+		
 		return CommandOutput(proc.returncode, stdout, stderr)
-
+	
 	@staticmethod
 	def run(command, cwd=None, shell=False, raiseOnError=False):
 		"""
 		Executes a child process and waits for it to complete
 		"""
-
+		
 		# If verbose output is enabled, print the command that will be executed
 		Utility._printCommand(command)
-
+		
 		returncode = subprocess.call(command, cwd=cwd, shell=shell)
 		if raiseOnError == True and returncode != 0:
 			raise Exception('child process ' + str(command) + ' failed with exit code ' + str(returncode))
 		return returncode
-
+	
 	@staticmethod
 	def _printCommand(command):
 		"""


### PR DESCRIPTION
Hey @adamrehn 

`shellescape.quote()` is very outdated in 2024. Said method is just a backport of shlex.quote() to versions of Python earlier than 3.8 - https://github.com/chrissimpkins/shellescape

Python 3.7 is almost 6 years old, so its' probably not worth to support such old versions - https://endoflife.date/python

`shellescape` is the only real dependency of `ue4cli`, dropping it would mean that running cli code would be simpler in external apps. I wanted to use it in one of my plugins and that was pretty much the only thing bothering me.

DISCLAIMER:
I'm not sure if this can broke the pypi package distribution. I don't have a valid way to test that.
However, using `python ./setup.py build` and `python ./setup.py install` worked fine on my side.
