### PR TITLE
Allow to run non-Development Editor + few minor fixes in the same code

### DIFF
--- a/ue4cli/UnrealManagerBase.py
+++ b/ue4cli/UnrealManagerBase.py
@@ -24,6 +24,13 @@ class UnrealManagerBase(object):
 		"""
 		return ['Debug', 'DebugGame', 'Development', 'Shipping', 'Test']
 	
+	def validBuildTargets(self):
+		"""
+		Returns the list of valid build targets supported by UnrealBuildTool
+		"""
+		# FIXME: Missing support for 'Program' build target: https://docs.unrealengine.com/5.3/en-US/unreal-engine-build-tool-target-reference/
+		return ['Game', 'Editor', 'Client', 'Server']
+	
 	def getPlatformIdentifier(self):
 		"""
 		Returns the platform identifier for the current platform, as used by UnrealBuildTool
@@ -117,15 +124,19 @@ class UnrealManagerBase(object):
 		sentinelFile = os.path.join(self.getEngineRoot(), 'Engine', 'Build', 'InstalledBuild.txt')
 		return os.path.exists(sentinelFile)
 	
-	def getEditorBinary(self, cmdVersion=False):
+	def getEditorBinary(self, cmdVersion=False, configuration='Development'):
 		"""
 		Determines the location of the UE4Editor/UnrealEditor binary
 		"""
-		if self._getEngineVersionDetails()['MajorVersion'] >= 5:
-			return os.path.join(self.getEngineRoot(), 'Engine', 'Binaries', self.getPlatformIdentifier(), 'UnrealEditor' + self._editorPathSuffix(cmdVersion))
-		else:
-			return os.path.join(self.getEngineRoot(), 'Engine', 'Binaries', self.getPlatformIdentifier(), 'UE4Editor' + self._editorPathSuffix(cmdVersion))	
-
+		supportedConfigurations = ['Debug', 'DebugGame', 'Development']
+		if configuration not in supportedConfigurations:
+			raise UnrealManagerException("Editor supports only following configurations: " + str(supportedConfigurations))
+		platformIdentifier = self.getPlatformIdentifier()
+		coreName = 'UnrealEditor' if self._getEngineVersionDetails()['MajorVersion'] >= 5 else 'UE4Editor'
+		if configuration != 'Development':
+			coreName += '-' + platformIdentifier + '-' + configuration
+		return os.path.join(self.getEngineRoot(), 'Engine', 'Binaries', platformIdentifier, coreName + self._editorPathSuffix(cmdVersion))
+	
 	def getBuildScript(self):
 		"""
 		Determines the location of the script file to perform builds
@@ -360,6 +371,9 @@ class UnrealManagerBase(object):
 		# Verify that the specified build configuration is valid
 		if configuration not in self.validBuildConfigurations():
 			raise UnrealManagerException('invalid build configuration "' + configuration + '"')
+		# Verify that the specified build target is valid
+		if target not in self.validBuildTargets():
+			raise UnrealManagerException('invalid build target "' + target + '"')
 		
 		# Check if the user specified the `-notools` flag to opt out of building Engine tools when working with source builds
 		unstripped = list(args)
@@ -370,6 +384,10 @@ class UnrealManagerBase(object):
 		if noTools == False and self.isInstalledBuild() == False and self.isProject(descriptor) and target == 'Editor':
 			Utility.printStderr('Ensuring ShaderCompileWorker is built before building project Editor modules...')
 			self.buildTarget('ShaderCompileWorker', 'Development', [], suppressOutput)
+		
+		# Game target does NOT use any postfix
+		if target == 'Game':
+			target = ''
 		
 		# Generate the arguments to pass to UBT
 		if self._getEngineVersionDetails()['MajorVersion'] >= 5:
@@ -387,13 +405,13 @@ class UnrealManagerBase(object):
 		"""
 		self._runUnrealBuildTool(target, self.getPlatformIdentifier(), configuration, args, capture=suppressOutput)
 	
-	def runEditor(self, dir=os.getcwd(), debug=False, args=[]):
+	def runEditor(self, dir=os.getcwd(), debug=False, args=[], configuration='Development'):
 		"""
 		Runs the editor for the Unreal project in the specified directory (or without a project if dir is None)
 		"""
 		projectFile = self.getProjectDescriptor(dir) if dir is not None else ''
 		extraFlags = ['-debug'] + args if debug == True else args
-		Utility.run([self.getEditorBinary(True), projectFile] + extraFlags + ['-stdout', '-FullStdOutLogOutput'], raiseOnError=True)
+		Utility.run([self.getEditorBinary(True, configuration), projectFile] + extraFlags + ['-stdout', '-FullStdOutLogOutput'], raiseOnError=True)
 	
 	def runUAT(self, args):
 		"""

--- a/ue4cli/UnrealManagerBase.py
+++ b/ue4cli/UnrealManagerBase.py
@@ -22,14 +22,20 @@ class UnrealManagerBase(object):
 		"""
 		Returns the list of valid build configurations supported by UnrealBuildTool
 		"""
-		return ['Debug', 'DebugGame', 'Development', 'Shipping', 'Test']
+		baseConfigurations = ['DebugGame', 'Development', 'Shipping']
+		if not self.isInstalledBuild():
+			baseConfigurations += ['Debug', 'Test']
+		return baseConfigurations
 	
 	def validBuildTargets(self):
 		"""
 		Returns the list of valid build targets supported by UnrealBuildTool
 		"""
 		# FIXME: Missing support for 'Program' build target: https://docs.unrealengine.com/5.3/en-US/unreal-engine-build-tool-target-reference/
-		return ['Game', 'Editor', 'Client', 'Server']
+		baseTargets = ['Game', 'Editor']
+		if not self.isInstalledBuild():
+			baseTargets += ['Client', 'Server']
+		return baseTargets
 	
 	def getPlatformIdentifier(self):
 		"""

--- a/ue4cli/cli.py
+++ b/ue4cli/cli.py
@@ -45,8 +45,8 @@ SUPPORTED_COMMANDS = {
 	
 	'editor': {
 		'description': 'Run the editor without an Unreal project (useful for creating new projects)',
-		'action': lambda m, args: m.runEditor(None, False, args),
-		'args': '[EXTRA ARGS]'
+		'action': lambda m, args: m.runEditor(None, False, args, args.pop(0) if (len(args) > 0) else 'Development'),
+		'args': '[CONFIGURATION] [EXTRA ARGS]'
 	},
 	
 	'build-target': {
@@ -60,9 +60,10 @@ SUPPORTED_COMMANDS = {
 		'action': lambda m, args: m.runEditor(
 			os.getcwd(),
 			True if '--debug' in args else False,
-			list([arg for arg in args if arg != '--debug'])
+			list([arg for arg in args if arg != '--debug']),
+			args.pop(0) if (len(args) > 0 and args[0].startswith('-') == False) else 'Development',
 		),
-		'args': '[--debug] [EXTRA ARGS]'
+		'args': '[CONFIGURATION] [--debug] [EXTRA ARGS]'
 	},
 	
 	'gen': {


### PR DESCRIPTION
Hi @adamrehn ,

I fixed the suport for launching non-Development Editor https://github.com/adamrehn/ue4cli/issues/56 There are also few other changes and fixes added by this PR, as they were either easy to fix, located in the same code or blocking me from fixing the mentioned issue. I tested it mostly on Linux but it **should work**™ on other platforms too since the underlying code was already there.

I also tried to deal with https://github.com/adamrehn/ue4cli/issues/61 and https://github.com/adamrehn/ue4cli/issues/62 but they don't seem worth fixing right now (see the comments under those issues). Though, some changes were made with those in mind.

Let me know what do you think. PR is open for your edits.

Cheers!

All changes:
- API now allow to run non-Development Editor
- You can do stuff like `ue4 run DebugGame` and `ue4 editor DebugGame` as both these commands now take `[CONFIGURATION]` as optional parameter
- Fix: https://github.com/adamrehn/ue4cli/issues/56
- add `validBuildTargets` helper function that behaves similar as `validBuildConfigurations`
- Fix: add validation for build target inside of `getBuildScript` as this was not handled anywhere unlike build configuration
- Fix: `validBuildTargets`/`Configurations` now take into consideration if UE is installed via EpicLauncher or not (now the behavior lines up with [the tables on this page](https://docs.unrealengine.com/5.3/en-US/build-configurations-reference-for-unreal-engine/))
- allow to build Game target inside of `getBuildScript` as this was fairly easy to add was surprisingly not supported
- added small FIXME note that we are missing support for 'Program' build target