### PR TITLE
fix: I/O failures causing a crash +  unify logging and assertions

### DIFF
--- a/ue4cli/CachedDataManager.py
+++ b/ue4cli/CachedDataManager.py
@@ -1,6 +1,7 @@
 from .ConfigurationManager import ConfigurationManager
 from .JsonDataManager import JsonDataManager
-import os, shutil
+from .Utility import Utility
+import os
 
 class CachedDataManager(object):
 	"""
@@ -13,7 +14,7 @@ class CachedDataManager(object):
 		Clears any cached data we have stored about specific engine versions
 		"""
 		if os.path.exists(CachedDataManager._cacheDir()) == True:
-			shutil.rmtree(CachedDataManager._cacheDir())
+			Utility.removeDir(CachedDataManager._cacheDir())
 	
 	@staticmethod
 	def getCachedDataKey(engineVersionHash, key):

--- a/ue4cli/JsonDataManager.py
+++ b/ue4cli/JsonDataManager.py
@@ -16,15 +16,16 @@ class JsonDataManager(object):
 
 	def loads(self):
 		"""
-		Wrapper for json.loads which reads owned jsonFile and loads it
-		In case of encountering JSONDecodeError, it will raise UtilityException
+		Reads and loads owned jsonFile
 		"""
 		try:
 			path = self.jsonFile
 			file = Utility.readFile(path)
 			return json.loads(file)
 		except json.JSONDecodeError as e:
-			raise UtilityException(f'failed to load {str(path)} due to {type(e).__name__} {str(e)}')
+			# FIXME: This is the only place outside of Utility class where we use UtilityException.
+			# Not worth to create new Exception class for only one single case, at least not now.
+			raise UtilityException(f'failed to load "{str(path)}" due to: ({type(e).__name__}) {str(e)}')
 	
 	def getKey(self, key):
 		"""

--- a/ue4cli/JsonDataManager.py
+++ b/ue4cli/JsonDataManager.py
@@ -1,5 +1,6 @@
 from .UnrealManagerException import UnrealManagerException
 from .Utility import Utility
+from .UtilityException import UtilityException
 import json, os, platform
 
 class JsonDataManager(object):
@@ -28,7 +29,10 @@ class JsonDataManager(object):
 		Retrieves the entire data dictionary
 		"""
 		if os.path.exists(self.jsonFile):
-			return json.loads(Utility.readFile(self.jsonFile))
+			try:
+				return json.loads(Utility.readFile(self.jsonFile))
+			except json.JSONDecodeError as e:
+				raise UtilityException(f'failed to load {str(self.jsonFile)} due to {type(e).__name__} {str(e)}')
 		else:
 			return {}
 	
@@ -48,7 +52,10 @@ class JsonDataManager(object):
 		# Create the directory containing the JSON file if it doesn't already exist
 		jsonDir = os.path.dirname(self.jsonFile)
 		if os.path.exists(jsonDir) == False:
-			os.makedirs(jsonDir)
+			try:
+				os.makedirs(jsonDir)
+			except OSError as e:
+				raise UtilityException(f'failed to create directory {str(jsonDir)} due to {type(e).__name__} {str(e)}')
 		
 		# Store the dictionary
 		Utility.writeFile(self.jsonFile, json.dumps(data))

--- a/ue4cli/JsonDataManager.py
+++ b/ue4cli/JsonDataManager.py
@@ -1,7 +1,7 @@
 from .UnrealManagerException import UnrealManagerException
 from .Utility import Utility
 from .UtilityException import UtilityException
-import json, os, platform
+import json, os
 
 class JsonDataManager(object):
 	"""
@@ -13,6 +13,18 @@ class JsonDataManager(object):
 		Creates a new JsonDataManager instance for the specified JSON file
 		"""
 		self.jsonFile = jsonFile
+
+	def loads(self):
+		"""
+		Wrapper for json.loads which reads owned jsonFile and loads it
+		In case of encountering JSONDecodeError, it will raise UtilityException
+		"""
+		try:
+			path = self.jsonFile
+			file = Utility.readFile(path)
+			return json.loads(file)
+		except json.JSONDecodeError as e:
+			raise UtilityException(f'failed to load {str(path)} due to {type(e).__name__} {str(e)}')
 	
 	def getKey(self, key):
 		"""
@@ -29,10 +41,7 @@ class JsonDataManager(object):
 		Retrieves the entire data dictionary
 		"""
 		if os.path.exists(self.jsonFile):
-			try:
-				return json.loads(Utility.readFile(self.jsonFile))
-			except json.JSONDecodeError as e:
-				raise UtilityException(f'failed to load {str(self.jsonFile)} due to {type(e).__name__} {str(e)}')
+			return self.loads()
 		else:
 			return {}
 	
@@ -52,10 +61,7 @@ class JsonDataManager(object):
 		# Create the directory containing the JSON file if it doesn't already exist
 		jsonDir = os.path.dirname(self.jsonFile)
 		if os.path.exists(jsonDir) == False:
-			try:
-				os.makedirs(jsonDir)
-			except OSError as e:
-				raise UtilityException(f'failed to create directory {str(jsonDir)} due to {type(e).__name__} {str(e)}')
+			Utility.makeDirs(jsonDir)
 		
 		# Store the dictionary
 		Utility.writeFile(self.jsonFile, json.dumps(data))

--- a/ue4cli/JsonDataManager.py
+++ b/ue4cli/JsonDataManager.py
@@ -25,7 +25,7 @@ class JsonDataManager(object):
 		except json.JSONDecodeError as e:
 			# FIXME: This is the only place outside of Utility class where we use UtilityException.
 			# Not worth to create new Exception class for only one single case, at least not now.
-			raise UtilityException(f'failed to load "{str(path)}" due to: ({type(e).__name__}) {str(e)}')
+			raise UtilityException(f'failed to load "{str(path)}" due to: ({type(e).__name__}) {str(e)}') from e
 	
 	def getKey(self, key):
 		"""

--- a/ue4cli/JsonDataManager.py
+++ b/ue4cli/JsonDataManager.py
@@ -28,10 +28,7 @@ class JsonDataManager(object):
 		Retrieves the entire data dictionary
 		"""
 		if os.path.exists(self.jsonFile):
-			try:
-				return json.loads(Utility.readFile(self.jsonFile))
-			except json.JSONDecodeError as err:
-				raise UnrealManagerException('malformed JSON configuration file "{}" ({})'.format(self.jsonFile, err))
+			return json.loads(Utility.readFile(self.jsonFile))
 		else:
 			return {}
 	

--- a/ue4cli/UnrealManagerBase.py
+++ b/ue4cli/UnrealManagerBase.py
@@ -50,7 +50,7 @@ class UnrealManagerBase(object):
 		try:
 			self.getEngineVersion()
 		except:
-			UnrealManagerException('the specified directory does not appear to contain a valid version of the Unreal Engine.')
+			raise UnrealManagerException('the specified directory does not appear to contain a valid version of the Unreal Engine.')
 	
 	def clearEngineRootOverride(self):
 		"""

--- a/ue4cli/UnrealManagerBase.py
+++ b/ue4cli/UnrealManagerBase.py
@@ -52,7 +52,7 @@ class UnrealManagerBase(object):
 		try:
 			self.getEngineVersion()
 		except:
-			raise UnrealManagerException('the specified directory does not appear to contain a valid version of the Unreal Engine.')
+			raise UnrealManagerException('the specified directory does not appear to contain a valid version of the Unreal Engine.') from None
 	
 	def clearEngineRootOverride(self):
 		"""
@@ -96,7 +96,7 @@ class UnrealManagerBase(object):
 		
 		# Verify that the requested output format is valid
 		if outputFormat not in formats:
-			raise UnrealManagerException('unreconised version output format "{}"'.format(outputFormat))
+			raise UnrealManagerException(f'unreconised version output format "{str(outputFormat)}"')
 		
 		return formats[outputFormat]
 	
@@ -176,7 +176,7 @@ class UnrealManagerBase(object):
 			try:
 				return self.getPluginDescriptor(dir)
 			except:
-				raise UnrealManagerException('could not detect an Unreal project or plugin in the directory "{}"'.format(dir))
+				raise UnrealManagerException(f'could not detect an Unreal project or plugin in the directory "{str(dir)}"') from None
 	
 	def isProject(self, descriptor):
 		"""
@@ -355,11 +355,11 @@ class UnrealManagerBase(object):
 		
 		# If the project or plugin is Blueprint-only, there is no C++ code to build
 		if os.path.exists(os.path.join(dir, 'Source')) == False:
-			raise UnrealManagerException('Pure Blueprint {}, nothing to build.'.format(descriptorType))
+			raise UnrealManagerException(f'Pure Blueprint {str(descriptorType)}, nothing to build.')
 		
 		# Verify that the specified build configuration is valid
 		if configuration not in self.validBuildConfigurations():
-			raise UnrealManagerException('invalid build configuration "' + configuration + '"')
+			raise UnrealManagerException(f'invalid build configuration "{str(configuration)}"')
 		
 		# Check if the user specified the `-notools` flag to opt out of building Engine tools when working with source builds
 		unstripped = list(args)
@@ -408,7 +408,7 @@ class UnrealManagerBase(object):
 		
 		# Verify that the specified build configuration is valid
 		if configuration not in self.validBuildConfigurations():
-			raise UnrealManagerException('invalid build configuration "' + configuration + '"')
+			raise UnrealManagerException(f'invalid build configuration "{str(configuration)}"')
 		
 		# Strip out the `-NoCompileEditor` flag if the user has specified it, since the Development version
 		# of the Editor modules for the project are needed in order to run the commandlet that cooks content
@@ -538,10 +538,12 @@ class UnrealManagerBase(object):
 		# Detect if the Editor terminated abnormally (i.e. not triggered by `automation quit`)
 		# In Unreal Engine 4.27.0, the exit method changed from RequestExit to RequestExitWithStatus
 		if 'PlatformMisc::RequestExit(' not in logOutput.stdout and 'PlatformMisc::RequestExitWithStatus(' not in logOutput.stdout:
-			raise UnrealManagerException(
-				'failed to retrieve the list of automation tests!' +
-				' stdout was: "{}", stderr was: "{}"'.format(logOutput.stdout, logOutput.stderr)
-			)
+			Utility.printStderr("Warning: abnormal Editor termination detected!")
+			Utility.printStderr("printing stdout..")
+			print(logOutput.stdout)
+			Utility.printStderr("printing stderr..")
+			print(logOutput.stderr)
+			raise UnrealManagerException('failed to retrieve the list of automation tests!')
 		
 		return sorted(list(tests))
 	

--- a/ue4cli/UnrealManagerBase.py
+++ b/ue4cli/UnrealManagerBase.py
@@ -624,8 +624,6 @@ class UnrealManagerBase(object):
 			match = re.search('TEST COMPLETE\\. EXIT CODE: ([0-9]+)', logOutput.stdout + logOutput.stderr)
 			if match is not None:
 				sys.exit(int(match.group(1)))
-			else:
-				raise UnrealManagerException('abnormal exit condition')
 	
 	# "Protected" methods
 	

--- a/ue4cli/UnrealManagerBase.py
+++ b/ue4cli/UnrealManagerBase.py
@@ -5,8 +5,9 @@ from .UE4BuildInterrogator import UE4BuildInterrogator
 from .CachedDataManager import CachedDataManager
 from .CMakeCustomFlags import CMakeCustomFlags
 from .Utility import Utility
+from .JsonDataManager import JsonDataManager
 from .UtilityException import UtilityException
-import glob, hashlib, json, os, re, shutil, sys
+import glob, hashlib, json, os, re
 
 class UnrealManagerBase(object):
 	"""
@@ -334,8 +335,8 @@ class UnrealManagerBase(object):
 		
 		# Because performing a clean will also delete the engine build itself when using
 		# a source build, we simply delete the `Binaries` and `Intermediate` directories
-		shutil.rmtree(os.path.join(dir, 'Binaries'), ignore_errors=True)
-		shutil.rmtree(os.path.join(dir, 'Intermediate'), ignore_errors=True)
+		Utility.removeDir(os.path.join(dir, 'Binaries'), ignore_errors=True)
+		Utility.removeDir(os.path.join(dir, 'Intermediate'), ignore_errors=True)
 		
 		# If we are cleaning a project, also clean any plugins
 		if self.isProject(descriptor):
@@ -642,11 +643,7 @@ class UnrealManagerBase(object):
 		Parses the JSON version details for the latest installed version of UE4
 		"""
 		versionFile = os.path.join(self.getEngineRoot(), 'Engine', 'Build', 'Build.version')
-		jsonFile = Utility.readFile(versionFile)
-		try:
-			return json.loads(jsonFile)
-		except json.JSONDecodeError as e:
-			raise UtilityException(f'failed to load {str(jsonFile)} due to {type(e).__name__} {str(e)}')
+		return JsonDataManager(versionFile).loads()
 	
 	def _getEngineVersionHash(self):
 		"""

--- a/ue4cli/UnrealManagerWindows.py
+++ b/ue4cli/UnrealManagerWindows.py
@@ -42,7 +42,7 @@ class UnrealManagerWindows(UnrealManagerBase):
 		except:
 			pass
 		
-		raise UnrealManagerException('could not detect the location of GenerateProjectFiles.bat or UnrealVersionSelector.exe.\nThis typically indicates that .uproject files are not correctly associated with UE4.')
+		raise UnrealManagerException('could not detect the location of GenerateProjectFiles.bat or UnrealVersionSelector.exe. This typically indicates that .uproject files are not correctly associated with UE4.')
 	
 	def getRunUATScript(self):
 		return self.getEngineRoot() + '\\Engine\\Build\\BatchFiles\\RunUAT.bat'

--- a/ue4cli/UnrealManagerWindows.py
+++ b/ue4cli/UnrealManagerWindows.py
@@ -52,7 +52,7 @@ class UnrealManagerWindows(UnrealManagerBase):
 		# If we are using our custom batch file, use the appropriate arguments
 		genScript = self.getGenerateScript()
 		projectFile = self.getProjectDescriptor(dir)
-		print(projectFile)
+		Utility.printStderr('Using project file:', projectFile)
 		if '.ue4\\GenerateProjectFiles.bat' in genScript:
 			Utility.run([genScript, projectFile], raiseOnError=True)
 		else:

--- a/ue4cli/UnrealManagerWindows.py
+++ b/ue4cli/UnrealManagerWindows.py
@@ -91,7 +91,7 @@ class UnrealManagerWindows(UnrealManagerBase):
 		# If the script directory doesn't already exist, attempt to create it
 		scriptDir = os.path.join(os.environ['HOMEDRIVE'] + os.environ['HOMEPATH'], '.ue4')
 		try:
-			os.makedirs(scriptDir)
+			Utility.makeDirs(scriptDir)
 		except:
 			pass
 		

--- a/ue4cli/Utility.py
+++ b/ue4cli/Utility.py
@@ -33,7 +33,7 @@ class Utility:
 			with open(filename, 'rb') as f:
 				return f.read().decode('utf-8')
 		except OSError as e:
-			raise UtilityException(f'failed to read file {str(filename)} due to {type(e).__name__} {str(e)}')
+			raise UtilityException(f'failed to read file "{str(filename)}" due to: ({type(e).__name__}) {str(e)}')
 	
 	@staticmethod
 	def writeFile(filename, data):
@@ -44,7 +44,7 @@ class Utility:
 			with open(filename, 'wb') as f:
 				f.write(data.encode('utf-8'))
 		except OSError as e:
-			raise UtilityException(f'failed to write file {str(filename)} due to {type(e).__name__} {str(e)}')
+			raise UtilityException(f'failed to write file "{str(filename)}" due to: ({type(e).__name__}) {str(e)}')
 	
 	@staticmethod
 	def moveFile(src, dst):
@@ -54,7 +54,7 @@ class Utility:
 		try:
 			shutil.move(src, dst)
 		except OSError as e:
-			raise UtilityException(f'failed to move {str(src)} to {str(dst)} due to {type(e).__name__} {str(e)}')
+			raise UtilityException(f'failed to move file from "{str(src)}" to "{str(dst)}" due to: ({type(e).__name__}) {str(e)}')
 	
 	@staticmethod
 	def patchFile(filename, replacements):
@@ -77,7 +77,7 @@ class Utility:
 		try:
 			shutil.rmtree(path, ignore_errors)
 		except OSError as e:
-			raise UtilityException(f'failed to remove directory {str(path)} due to {type(e).__name__} {str(e)}')
+			raise UtilityException(f'failed to remove directory "{str(path)}" due to: ({type(e).__name__}) {str(e)}')
 	
 	@staticmethod
 	def makeDirs(name, mode=0o777, exist_ok=False):
@@ -87,7 +87,7 @@ class Utility:
 		try:
 			os.makedirs(name, mode, exist_ok)
 		except OSError as e:
-			raise UtilityException(f'failed to create directory {str(name)} due to {type(e).__name__} {str(e)}')
+			raise UtilityException(f'failed to create directory "{str(name)}" due to: ({type(e).__name__}) {str(e)}')
 	
 	@staticmethod
 	def forwardSlashes(paths):

--- a/ue4cli/Utility.py
+++ b/ue4cli/Utility.py
@@ -21,7 +21,7 @@ class Utility:
 		Prints to stderr instead of stdout
 		"""
 		if os.environ.get('UE4CLI_QUIET', '0') != '1':
-			print(*args, file=sys.stderr, **kwargs)
+			print('(ue4cli)', *args, end='\n', file=sys.stderr, **kwargs)
 	
 	@staticmethod
 	def readFile(filename):
@@ -123,7 +123,7 @@ class Utility:
 		
 		# If the child process failed and we were asked to raise an exception, do so
 		if raiseOnError == True and proc.returncode != 0:
-			raise Exception(
+			raise subprocess.SubprocessError(
 				'child process ' + str(command) +
 				' failed with exit code ' + str(proc.returncode) +
 				'\nstdout: "' + stdout + '"' +
@@ -143,7 +143,7 @@ class Utility:
 		
 		returncode = subprocess.call(command, cwd=cwd, shell=shell)
 		if raiseOnError == True and returncode != 0:
-			raise Exception('child process ' + str(command) + ' failed with exit code ' + str(returncode))
+			raise subprocess.SubprocessError('child process ' + str(command) + ' failed with exit code ' + str(returncode))
 		return returncode
 	
 	@staticmethod
@@ -152,4 +152,4 @@ class Utility:
 		Prints a command if verbose output is enabled
 		"""
 		if os.environ.get('UE4CLI_VERBOSE', '0') == '1':
-			Utility.printStderr('[UE4CLI] EXECUTE COMMAND:', command)
+			Utility.printStderr('EXECUTE COMMAND:', command)

--- a/ue4cli/Utility.py
+++ b/ue4cli/Utility.py
@@ -33,7 +33,7 @@ class Utility:
 			with open(filename, 'rb') as f:
 				return f.read().decode('utf-8')
 		except OSError as e:
-			raise UtilityException(f'failed to read file "{str(filename)}" due to: ({type(e).__name__}) {str(e)}')
+			raise UtilityException(f'failed to read file "{str(filename)}" due to: ({type(e).__name__}) {str(e)}') from e
 	
 	@staticmethod
 	def writeFile(filename, data):
@@ -44,7 +44,7 @@ class Utility:
 			with open(filename, 'wb') as f:
 				f.write(data.encode('utf-8'))
 		except OSError as e:
-			raise UtilityException(f'failed to write file "{str(filename)}" due to: ({type(e).__name__}) {str(e)}')
+			raise UtilityException(f'failed to write file "{str(filename)}" due to: ({type(e).__name__}) {str(e)}') from e
 	
 	@staticmethod
 	def moveFile(src, dst):
@@ -54,7 +54,7 @@ class Utility:
 		try:
 			shutil.move(src, dst)
 		except OSError as e:
-			raise UtilityException(f'failed to move file from "{str(src)}" to "{str(dst)}" due to: ({type(e).__name__}) {str(e)}')
+			raise UtilityException(f'failed to move file from "{str(src)}" to "{str(dst)}" due to: ({type(e).__name__}) {str(e)}') from e
 	
 	@staticmethod
 	def patchFile(filename, replacements):
@@ -77,7 +77,7 @@ class Utility:
 		try:
 			shutil.rmtree(path, ignore_errors)
 		except OSError as e:
-			raise UtilityException(f'failed to remove directory "{str(path)}" due to: ({type(e).__name__}) {str(e)}')
+			raise UtilityException(f'failed to remove directory "{str(path)}" due to: ({type(e).__name__}) {str(e)}') from e
 	
 	@staticmethod
 	def makeDirs(name, mode=0o777, exist_ok=False):
@@ -87,7 +87,7 @@ class Utility:
 		try:
 			os.makedirs(name, mode, exist_ok)
 		except OSError as e:
-			raise UtilityException(f'failed to create directory "{str(name)}" due to: ({type(e).__name__}) {str(e)}')
+			raise UtilityException(f'failed to create directory "{str(name)}" due to: ({type(e).__name__}) {str(e)}') from e
 	
 	@staticmethod
 	def forwardSlashes(paths):

--- a/ue4cli/Utility.py
+++ b/ue4cli/Utility.py
@@ -1,5 +1,5 @@
 from .UtilityException import UtilityException
-import os, platform, shlex, subprocess, sys
+import os, platform, shlex, subprocess, sys, shutil
 
 class CommandOutput(object):
 	"""
@@ -47,6 +47,16 @@ class Utility:
 			raise UtilityException(f'failed to write file {str(filename)} due to {type(e).__name__} {str(e)}')
 	
 	@staticmethod
+	def moveFile(src, dst):
+		"""
+		Moves file from 'src' to 'dst'
+		"""
+		try:
+			shutil.move(src, dst)
+		except OSError as e:
+			raise UtilityException(f'failed to move {str(src)} to {str(dst)} due to {type(e).__name__} {str(e)}')
+	
+	@staticmethod
 	def patchFile(filename, replacements):
 		"""
 		Applies the supplied list of replacements to a file
@@ -58,6 +68,26 @@ class Utility:
 			patched = patched.replace(key, replacements[key])
 		
 		Utility.writeFile(filename, patched)
+	
+	@staticmethod
+	def removeDir(path, ignore_errors=False):
+		"""
+		Recursively remove directory tree
+		"""
+		try:
+			shutil.rmtree(path, ignore_errors)
+		except OSError as e:
+			raise UtilityException(f'failed to remove directory {str(path)} due to {type(e).__name__} {str(e)}')
+	
+	@staticmethod
+	def makeDirs(name, mode=0o777, exist_ok=False):
+		"""
+		Makes directory
+		"""
+		try:
+			os.makedirs(name, mode, exist_ok)
+		except OSError as e:
+			raise UtilityException(f'failed to create directory {str(name)} due to {type(e).__name__} {str(e)}')
 	
 	@staticmethod
 	def forwardSlashes(paths):

--- a/ue4cli/UtilityException.py
+++ b/ue4cli/UtilityException.py
@@ -1,0 +1,2 @@
+class UtilityException(Exception):
+	pass

--- a/ue4cli/cli.py
+++ b/ue4cli/cli.py
@@ -232,6 +232,7 @@ def main():
 			SubprocessError,
 			JSONDecodeError,
 			KeyboardInterrupt,
+			SystemExit,
 			) as e:
 		Utility.printStderr('(' + type(e).__name__ + ')', str(e))
 		sys.exit(1)

--- a/ue4cli/cli.py
+++ b/ue4cli/cli.py
@@ -227,7 +227,7 @@ def main():
 		else:
 			# FIXME: This is the only place outside of UnrealManager... classes where we use UnrealManagerException.
 			# Not worth to create new Exception class for only one single case, at least not now.
-			raise UnrealManagerException('unrecognised command "' + command + '"')
+			raise UnrealManagerException(f'unrecognised command "{str(command)}"') from None
 	
 	except (
 			UnrealManagerException,

--- a/ue4cli/cli.py
+++ b/ue4cli/cli.py
@@ -202,9 +202,10 @@ def displayHelp():
 		print()
 
 def main():
+	
+	logger = logging.getLogger(__name__)
+	
 	try:
-		logger = logging.getLogger(__name__)
-		
 		# Perform plugin detection and register our detected plugins
 		plugins = PluginManager.getPlugins()
 		for command in plugins:
@@ -224,14 +225,18 @@ def main():
 		if command in SUPPORTED_COMMANDS:
 			SUPPORTED_COMMANDS[command]['action'](manager, args)
 		else:
+			# FIXME: This is the only place outside of UnrealManager... classes where we use UnrealManagerException.
+			# Not worth to create new Exception class for only one single case, at least not now.
 			raise UnrealManagerException('unrecognised command "' + command + '"')
+	
 	except (
 			UnrealManagerException,
 			UtilityException,
 			KeyboardInterrupt,
 			) as e:
-		Utility.printStderr('(' + type(e).__name__ + ')', str(e))
+		Utility.printStderr(f'Error: ({type(e).__name__}) {str(e)}')
 		sys.exit(1)
+	
 	except BaseException as e:
 		Utility.printStderr('Unhandled exception! Crashing...')
 		logging.basicConfig(level=logging.DEBUG)

--- a/ue4cli/cli.py
+++ b/ue4cli/cli.py
@@ -3,8 +3,7 @@ from .PluginManager import PluginManager
 from .UnrealManagerException import UnrealManagerException
 from .UnrealManagerFactory import UnrealManagerFactory
 from .Utility import Utility
-from subprocess import SubprocessError
-from json import JSONDecodeError
+from .UtilityException import UtilityException
 import os, sys, logging
 
 # Our list of supported commands
@@ -228,11 +227,8 @@ def main():
 			raise UnrealManagerException('unrecognised command "' + command + '"')
 	except (
 			UnrealManagerException,
-			OSError,
-			SubprocessError,
-			JSONDecodeError,
+			UtilityException,
 			KeyboardInterrupt,
-			SystemExit,
 			) as e:
 		Utility.printStderr('(' + type(e).__name__ + ')', str(e))
 		sys.exit(1)
@@ -242,5 +238,4 @@ def main():
 		logger.exception(e)
 		Utility.printStderr('ue4cli has crashed! Please, report it at: https://github.com/adamrehn/ue4cli/issues')
 		sys.exit(1)
-
 


### PR DESCRIPTION
Hi @adamrehn ,

I reviewed all code related to I/O and made it consistent. Now, whenever we log something, we print it to the stderr with `(ue4cli) ` prefix. Commands that expect to return something still print to stdout. Every exception related to I/O is handled in one place, so now user should not be scared by python callstacks in situations that are perfectly fine. Also found some strange places that were raising default `Exception`, exiting or printing instead of asserting - I fixed them all.

Tested only on Linux, but I haven't touched anything platform-specific. As always let me know in case something is not right. PR is open for your edits.

EDIT: Also, please see comments below for more info

Cheers!