### PR TITLE
Fix: move __main__.py one directory higher, so it can be properly used

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -1,8 +1,8 @@
-from .cli import main
+from ue4cli.cli import main
 import os, sys
 
 if __name__ == '__main__':
-	
+
 	# Rewrite sys.argv[0] so our help prompts display the correct base command
 	interpreter = sys.executable if sys.executable not in [None, ''] else 'python3'
 	sys.argv[0] = '{} -m ue4cli'.format(os.path.basename(interpreter))


### PR DESCRIPTION
Please, see linked issue for reference https://github.com/adamrehn/ue4cli/issues/69
Now, ue4cli can be invoked without installing it and without making additional scripts.
Simply calling `python /path/to/ue4cli` will work.